### PR TITLE
Move @types/node to devDependencies

### DIFF
--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -37,7 +37,6 @@
     "url": "https://github.com/C2FO/fast-csv/issues"
   },
   "dependencies": {
-    "@types/node": "^14.0.1",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.isboolean": "^3.0.3",
     "lodash.isequal": "^4.5.0",
@@ -49,6 +48,7 @@
     "@types/lodash.isboolean": "3.0.6",
     "@types/lodash.isequal": "4.5.5",
     "@types/lodash.isfunction": "3.0.6",
-    "@types/lodash.isnil": "4.0.6"
+    "@types/lodash.isnil": "4.0.6",
+    "@types/node": "^14.0.1"
   }
 }

--- a/packages/parse/package.json
+++ b/packages/parse/package.json
@@ -38,7 +38,6 @@
     "url": "https://github.com/C2FO/fast-csv/issues"
   },
   "dependencies": {
-    "@types/node": "^14.0.1",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.groupby": "^4.6.0",
     "lodash.isfunction": "^3.0.9",
@@ -54,6 +53,7 @@
     "@types/lodash.isundefined": "3.0.6",
     "@types/lodash.partition": "4.6.6",
     "@types/lodash.uniq": "4.5.6",
+    "@types/node": "^14.0.1",
     "@types/sinon": "10.0.2",
     "lodash.partition": "4.6.0",
     "sinon": "11.1.2"


### PR DESCRIPTION
@types/node@14.0.1 drops support for typescript older 3.8
there is no reason to add this dependency on production - it is used only to build package

#### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/c2fo/fast-csv/pulls) for the same update/change?

#### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

